### PR TITLE
ZEN-22652: Include all nodes in 'Top Level Oranizers'

### DIFF
--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
@@ -1616,7 +1616,7 @@
     Ext.define('Zenoss.Dashboard.portlets.TopLevelOrganizersPortlet', {
         extend: 'Zenoss.Dashboard.view.Portlet',
         alias: 'widget.toplevelorganizersportlet',
-        title: _t('Top Level Organizers'),
+        title: _t('Organizers'),
         height: 400,
         rootOrganizer: '',
         childOrganizer: '',

--- a/ZenPacks/zenoss/Dashboard/facades.py
+++ b/ZenPacks/zenoss/Dashboard/facades.py
@@ -171,8 +171,6 @@ class DashboardFacade(ZuulFacade):
         for brain in searchresults:
             try:
                 org = brain.getObject()
-                if org.children():
-                    continue
                 info = IInfo(org)
                 info.fullOrganizerName = self._getFullOrganizerName(org)
                 results.append(info)


### PR DESCRIPTION
Previously only leaf nodes where included in this portlet

[Jira](https://jira.zenoss.com/browse/ZEN-22652)