### PR TITLE
ZEN-22400: Render URL's in Daemon Processes Down portlet

### DIFF
--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
@@ -584,7 +584,10 @@
                     columns: [{
                         dataIndex:'host',
                         header: _t('Host'),
-                        width: 120
+                        width: 120,
+                        renderer: function(url) {
+                            return Ext.String.format("{0}", url);
+                        }
                     },{
                         dataIndex: 'process',
                         header: _t('Daemon Process'),


### PR DESCRIPTION
All links in Daemon Processes Down portlet were shows as raw html,
added Ext.String.format() method to display them correctly.

Co-Authored-By: Oles Baiko <obaiko@zenoss.com>