### PR TITLE
ZEN-23612 Device Chart Portlet does not draw properly

### DIFF
--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/europaportlets.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/europaportlets.js
@@ -17,6 +17,7 @@
         extend: 'Zenoss.Dashboard.view.Portlet',
         alias: 'widget.devicechartportlet',
         height: 500,
+        overflowY: 'auto',
         title: 'Device Chart',
         deviceClass: '/',
         graphPoints: [],


### PR DESCRIPTION
This is the port from zenoss/ZenPacks.zenoss.Dashboard#52