### PR TITLE
ZEN-25372 Users with roles below ZManager have bad permissions on D…

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -40,13 +40,13 @@ The following, default portlets are defined by this ZenPack:
 * And more...
 
 == Permissions ==
-* There are no owner-level permissions associated with dashboard objects. Any user may edit a dashboard if they have "Change Device" permission.
-* Users with "Add DMD Objects" permission may add a dashboard.
-* User with "Delete Objects" permission may remove a dashboard.
+* All users are able to create their own dashboards to view objects that they are authorized to see. This includes users with the "ZenUser" role or even no global role.
+* All users in user groups are able to edit, add and remove portlets and edit dashboards that are in their Group visibility level.
+* The default dashboard is readonly for users that have no "Manage DMD" permission.
+* Only Manager are able to edit default dashboard. For all other users the default dashboard is readonly.
+* All users are able to edit, add and remove portlets and edit dashboard that is in Global visibility level. Only Owner and Manager are able to remove Global dashboards.
 * Permissions are checked both on the client and server.
 * If the Audit ZenPack is installed, all operations on dashboards are audited.
-
-The "Add DMD Objects" and "Delete Objects" permissions are are global roles; the context of dashboard objects can not have permissions applied to them.
 
 == Writing a new Portlet ==
 

--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/controller/DashboardController.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/controller/DashboardController.js
@@ -93,6 +93,18 @@
                     }).show();
 		    return;
 		}
+            if (dashboard.get('uid') === "/zport/dmd/ZenUsers/dashboards/default" &&
+                Zenoss.Security.doesNotHavePermission('Manage DMD')) {
+                new Zenoss.dialog.SimpleMessageDialog({
+                    message: _t("You can not add a Portlet to the default Dashboard"),
+                    title: _t('Add portlet'),
+                    buttons: [{
+                        xtype: 'DialogButton',
+                        text: _t('Close')
+                    }]
+                }).show();
+                return;
+            }
                 var win = Ext.create('Zenoss.Dashboard.view.AddPortletDialog', {});
                 // save handler for the dialog
                 win.query('button')[0].on('click', function() {
@@ -161,6 +173,18 @@
         editSelectedDashboard: function() {
             var dashboard = this.getCurrentDashboard();
             if (dashboard) {
+                if (dashboard.get('uid') === "/zport/dmd/ZenUsers/dashboards/default" &&
+                    Zenoss.Security.doesNotHavePermission('Manage DMD')) {
+                    new Zenoss.dialog.SimpleMessageDialog({
+                        message: _t("You can not edit the default Dashboard"),
+                        title: _t('Edit Dashboard'),
+                        buttons: [{
+                            xtype: 'DialogButton',
+                            text: _t('Close')
+                        }]
+                    }).show();
+                    return;
+                }
                 var win = Ext.create('Zenoss.Dashboard.view.EditDashboardDialog', {
                     dashboard: dashboard
                 });
@@ -255,10 +279,11 @@
          **/
         saveDashboardState: function() {
             var dashboard = this.getCurrentDashboard(),
-                state = this.getCurrentDashboardState();
+                state = this.getCurrentDashboardState(),
+                panel = this.getDashboardPanel();
 
             // if the dashboard is locked then do not update the server with a new state
-            if (dashboard.get('locked')) {
+            if (dashboard.get('locked') || panel.query('portlet')[0].resizable === false) {
                 return;
             }
 
@@ -350,6 +375,14 @@
                 panel.add(columns);
                 // disable editing features on all the portlets if we are locked
                 if (dashboard.get('locked')) {
+                    Ext.each(panel.query('portlet'), function(portlet){
+                        portlet.lock()
+                    });
+                }
+                // disable editing features on all the portlets in default dashboard
+                // if user hasn`t 'Manage DMD' permission
+                if (dashboard.get('uid') === "/zport/dmd/ZenUsers/dashboards/default" &&
+                    Zenoss.Security.doesNotHavePermission('Manage DMD')) {
                     Ext.each(panel.query('portlet'), function(portlet){
                         portlet.lock()
                     });

--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/view/DashboardPanel.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/view/DashboardPanel.js
@@ -443,7 +443,6 @@
                     },'->',{
                         xtype: 'button',
                         iconCls:'add',
-                        hidden: Zenoss.Security.doesNotHavePermission('Add DMD Objects'),
                         menu: [{
                             text: _t('Add Portlet'),
                             itemId: 'newPortlet'
@@ -454,12 +453,10 @@
                     },{
                         xtype:'button',
                         iconCls:'delete',
-                        hidden: Zenoss.Security.doesNotHavePermission('Delete objects'),
                         itemId: 'deleteDashboard'
                     },{
                         xtype: 'button',
                         iconCls: 'customize',
-                        hidden: Zenoss.Security.doesNotHavePermission('Change Device'),
                         itemId: 'editDashboard'
                     }]
                 }],


### PR DESCRIPTION
This fix provide next abilities for users:
All users are able to create their own dashboards to view objects that they are authorized to see. This includes users with the "ZenUser" role or even no global role;
All Users in user groups are able to edit, add and remove portlets and edit dashboards that are in their Group visibility level;
The default dashboard is readonly for users that have no "Manage DMD" permission;
Only Manager are able to edit default dashboard. For all other users the default dashboard is readonly;
All users are able to edit, add and remove portlets and edit dashboard that is in Global visibility level. Only Owner and Manager are able to remove Global dashboards;

[Jira](https://jira.zenoss.com/browse/ZEN-25372)