### PR TITLE
ZEN-23411: add checkbox to Dashboard settings to turn off the audit logs

### DIFF
--- a/ZenPacks/zenoss/Dashboard/Dashboard.py
+++ b/ZenPacks/zenoss/Dashboard/Dashboard.py
@@ -17,6 +17,7 @@ class Dashboard(ZenModelRM):
     columns = 3
     state = ""
     locked = False
+    audit = True
 
     _properties =  (
         {'id':'name', 'type':'string', 'mode':'w'},
@@ -24,6 +25,7 @@ class Dashboard(ZenModelRM):
         {'id':'columns', 'type':'integer', 'mode':'w'},
         {'id':'state', 'type':'string', 'mode':'w'},
         {'id':'locked', 'type':'boolean', 'mode':'w'},
+        {'id':'audit', 'type':'boolean', 'mode':'w'},
     )
 
 

--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/controller/DashboardController.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/controller/DashboardController.js
@@ -299,6 +299,7 @@
             state = this.getCurrentDashboardState();
             Zenoss.remote.DashboardRouter.saveDashboardState({
                 uid: dashboard.get('uid'),
+                audit: dashboard.get('audit'),
                 state: state
             });
         },

--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/model/Dashboard.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/model/Dashboard.js
@@ -33,7 +33,7 @@
     Ext.define("Zenoss.Dashboard.model.Dashboard", {
         extend: 'Ext.data.Model',
         idProperty: 'uid',
-        fields: ['uid', 'id', 'name', 'columns', 'contextUid', 'contextType', 'state', 'owner', 'locked',
+        fields: ['uid', 'id', 'name', 'columns', 'contextUid', 'contextType', 'state', 'owner', 'locked', 'audit',
                  {
                      name: 'idwithOwner',
                      convert: function(v, record){

--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/view/DashboardPanel.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/view/DashboardPanel.js
@@ -340,7 +340,7 @@
             var me = this;
             Ext.applyIf(config, {
                 title: Ext.String.format(_t('Edit Dashboard {0}'), config.dashboard.get('id')),
-                height: 300,
+                height: 340,
                 width: 325,
                 layout: 'anchor',
                 defaults: {
@@ -366,7 +366,13 @@
                     minValue: 1,
                     maxValue: 10,
                     value: config.dashboard.get('columns')
-                },{
+                }, {
+                    xtype: 'checkbox',
+                    fieldLabel: _t('Audit logs?'),
+                    name: 'audit',
+                    itemId: 'audit',
+                    checked: config.dashboard.get('audit')
+                }, {
                     xtype: 'checkbox',
                     fieldLabel: _t('Lock from updates?'),
                     name: 'locked',
@@ -383,6 +389,7 @@
                             contextUid: me.down('dashboardcontext').getValue(),
                             columns: me.down('numberfield').getValue(),
                             locked: me.down('#locked').getValue(),
+                            audit: me.down('#audit').getValue(),
                             uid: me.dashboard.get('uid')
                         };
                         me.fireEvent('savedashboard', params);

--- a/ZenPacks/zenoss/Dashboard/info.py
+++ b/ZenPacks/zenoss/Dashboard/info.py
@@ -26,6 +26,7 @@ class DashboardInfo(InfoBase):
     columns = ProxyProperty('columns')
     state = ProxyProperty('state')
     locked = ProxyProperty('locked')
+    audit = ProxyProperty('audit')
 
     @property
     def contextUid(self):

--- a/ZenPacks/zenoss/Dashboard/routers.py
+++ b/ZenPacks/zenoss/Dashboard/routers.py
@@ -48,17 +48,17 @@ class DashboardRouter(DirectRouter):
     def saveDashboard(self, **data):
         facade = self._getFacade()
         result = facade.saveDashboard(data)
-        audit('UI.Dashboard.Edit', data_=data)
+        if data.get('audit'): audit('UI.Dashboard.Edit', data_=data)
         return DirectResponse.succeed(data=Zuul.marshal(result))
 
-    def saveDashboardState(self, uid, state):
+    def saveDashboardState(self, **data):
         """
         Updates the state attribute of the dashboard. This is called everytime a portlet is
         either dragged or resized.
         """
         facade = self._getFacade()
-        result = facade.saveDashboardState(uid, state)
-        audit('UI.Dashboard.Edit', state=state)
+        result = facade.saveDashboardState(data.get('uid'), data.get('state'))
+        if data.get('audit'): audit('UI.Dashboard.Edit', state=data.get('state'))
         return DirectResponse.succeed(data=Zuul.marshal(result))
 
     def getCurrentUsersGroups(self):


### PR DESCRIPTION
On display and refresh dashboard ZP generated dashboards audit logs
wich results in the audit log volume is excessively high.
Add new checkbox to dashboard settings which turn off the audit logs
for resizing and refreshing.

[JIRA](https://jira.zenoss.com/browse/ZEN-23411)