### PR TITLE
ZEN-28979: refresh PRODUCTION_STATES variable on portlet creation

### DIFF
--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
@@ -776,6 +776,7 @@
         initComponent: function(){
             Zenoss.env.initProductionStates();
             var store = Ext.create('Zenoss.DeviceStore', {});
+            this.getAllProductionState();
             store.setBaseParam('uid', '/zport/dmd/Devices');
             store.setBaseParam('keys', ['uid', 'name', 'productionState']);
             store.setParamsParam('productionState', this.productionStates);
@@ -813,6 +814,20 @@
             return {
                 productionStates: this.productionStates
             };
+        },
+        getAllProductionState: function() {
+            Zenoss.remote.DeviceRouter.getProductionStates({},
+                function(result) {
+                    if (result.success) {
+                        Zenoss.env.PRODUCTION_STATES = [];
+                        Zenoss.env.PRODUCTION_STATES_MAP = {};
+                        Ext.each(result.data, function(item) {
+                            Zenoss.env.PRODUCTION_STATES.push(item);
+                            Zenoss.env.PRODUCTION_STATES_MAP[item.value] = item.name;
+                        });
+                    };
+                }
+            );
         },
         applyConfig: function(config) {
             if (this.rendered) {


### PR DESCRIPTION
The devices with a custom production state are displayed but the
custom production state name is not if Dashboard page wasn't
reloaded when a new custom production state was added.
Update Global ProductionStates variable when initializing
Production State Portlet.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-28979)