### PR TITLE
ZEN-30094: removed Discovered device class from defalt list

### DIFF
--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
@@ -940,7 +940,7 @@
         alias: 'widget.watchlistportlet',
         title: _t('Watch List'),
         height: 300,
-        uids: ['/zport/dmd/Devices/Discovered'],
+        uids: [],
         initComponent: function(){
             var me = this,
                 store = Ext.create('Zenoss.Dashboard.stores.WatchListStore', {});


### PR DESCRIPTION
On a watch list portlet user is not able to remove Discovered
device class.
Occording to new changes we have a regex that add /cse to
all the string in js that has /zport/dmd so remove logic
was not able to match uid in a record and in the grid.
Removed the Discovered from default portlet state since there
is no point in keeping it.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-30094?focusedCommentId=129439&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-129439)