### PR TITLE
ZEN-30676: Validate the Google Maps portlet form after data receiving

### DIFF
--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
@@ -379,10 +379,17 @@
             }
         },
         getCustomConfigFields: function() {
+            var me = this;
+
             var store = Ext.create('Zenoss.Dashboard.stores.Organizer', {});
             store.load({
                 params: {
                     uid: "/zport/dmd/Locations"
+                },
+                callback: function(records, operation, success) {
+                    if (success && records.length) {
+                        me.up('form').isValid();
+                    }
                 }
             });
 


### PR DESCRIPTION
Since the `baselocation` combobox gets its options from the server, initially it has no data and is not valid. That is a reason why the `Add` button was disabled. We need to revalidate the form after the data receiving.

[Jira & Demo](https://jira.zenoss.com/browse/ZEN-30676?focusedCommentId=135420&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-135420)