### PR TITLE
ZEN-30818: Fix loading of dashboard page

### DIFF
--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/app.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/app.js
@@ -10,11 +10,15 @@
     // Fix for ZEN-30636
     if (Zenoss.env.CSE_VIRTUAL_ROOT) {
         var statePropertyKey = 'selected_dashboard';
+        var selectedDashboard = Ext.state.Manager.get(statePropertyKey);
+        var isSelectedDashboard = selectedDashboard && selectedDashboard['value'];
 
-        Ext.state.Manager.set(
-            statePropertyKey,
-            { value: Ext.state.Manager.get(statePropertyKey).value.replace(Zenoss.env.CSE_VIRTUAL_ROOT, '/') }
-        );
+        if (isSelectedDashboard) {
+            Ext.state.Manager.set(
+                statePropertyKey,
+                {value: selectedDashboard.value.replace(Zenoss.env.CSE_VIRTUAL_ROOT, '/')}
+            );
+        }
     }
 
     Ext.Loader.setConfig({


### PR DESCRIPTION
When a user logs in for the first time and opens Dashboard page for the first time its `Ext.state.Manager` doesn't have `selected_dashboard` property, so in this case, we need to skip removing cz prefix from `selected_dashboard` from `Ext.state.Manager`.