### PR TITLE
ZEN-30882: fix backward compatibility for older versions

### DIFF
--- a/ZenPacks/zenoss/Dashboard/__init__.py
+++ b/ZenPacks/zenoss/Dashboard/__init__.py
@@ -5,7 +5,6 @@ from zope.component import getUtility
 from Products.CMFCore.DirectoryView import registerDirectory
 from Products.ZenRelations.RelSchema import ToOne, ToManyCont
 from Products.ZenModel.UserSettings import UserSettings, UserSettingsManager
-from Products.ZenUtils.virtual_root import IVirtualRoot
 from ZenPacks.zenoss.Dashboard.Dashboard import Dashboard
 log = logging.getLogger('zen.dashboard')
 
@@ -23,6 +22,13 @@ UserSettingsManager._relations += SETTINGS_MANAGER_RELATIONSHIP
 skinsDir = os.path.join(os.path.dirname(__file__), 'skins')
 if os.path.isdir(skinsDir):
     registerDirectory(skinsDir, globals())
+
+try:
+    #backward compatibility for older RM versions
+    from Products.ZenUtils.virtual_root import IVirtualRoot
+    add_virtual_root = getUtility(IVirtualRoot).ensure_virtual_root
+except Exception:
+    add_virtual_root = lambda path: path
 
 from Products.ZenModel.ZenPack import ZenPack as ZenPackBase
 
@@ -56,7 +62,7 @@ class ZenPack(ZenPackBase):
         if not default:
             log.info("Creating the default Dashboard")
             site = {'core': 'core', 'enterprise': 'commercial'}[dmd.getProductName()]
-            baselocation = getUtility(IVirtualRoot).ensure_virtual_root("/zport/dmd/Locations")
+            baselocation = add_virtual_root("/zport/dmd/Locations")
             dashboard = Dashboard('default')
             dashboard.columns = 2
             dashboard.owner = 'admin'

--- a/ZenPacks/zenoss/Dashboard/migrate/updateDefaultGMapLocation.py
+++ b/ZenPacks/zenoss/Dashboard/migrate/updateDefaultGMapLocation.py
@@ -16,19 +16,23 @@ import json
 from zope.component import getUtility
 from Products.ZenModel.migrate.Migrate import Version
 from Products.ZenModel.ZenPack import ZenPackMigration
-from Products.ZenUtils.virtual_root import IVirtualRoot
-
+try:
+    #backward compatibility for older RM versions
+    from Products.ZenUtils.virtual_root import IVirtualRoot
+    add_virtual_root = getUtility(IVirtualRoot).ensure_virtual_root
+except Exception:
+    add_virtual_root = lambda path: path
 
 class updateDefaultGMapLocation(ZenPackMigration):
     """ Add cse prefix to base location of Google Map portlet"""
 
-    version = Version(1, 3, 0)
+    version = Version(1, 3, 3)
 
     def migrate(self, pack):
         if hasattr(pack.dmd.ZenUsers, 'dashboards'):
             changed = False
             baselocation_old = '/zport/dmd/Locations'
-            baselocation_new = getUtility(IVirtualRoot).ensure_virtual_root(baselocation_old)
+            baselocation_new = add_virtual_root(baselocation_old)
             default = pack.dmd.ZenUsers.dashboards._getOb('default', None)
             if default:
                 default_dashboard_json = json.loads(default.state)


### PR DESCRIPTION
In RM 6 and lower there was an Import Error on zenpack installation.
Prevent failing on lower versions by putting import in try/except.
Increase version in migration script to follow the next release
version.

The issue was caused by https://github.com/zenoss/ZenPacks.zenoss.Dashboard/pull/101

[JIRA](https://jira.zenoss.com/browse/ZEN-30882)