### PR TITLE
ZEN-25652: Fix validity of HTML before using it in HTMLPortlet

### DIFF
--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
@@ -283,6 +283,8 @@
         },
         applyConfig: function(config) {
             if (config.html && config.html !== this.content) {
+                config.html = this.convertToValidHTMLString(config.html);
+
                 this.content = config.html;
                 this.update(config.html, true);
             }
@@ -328,6 +330,12 @@
             return {
                 html: this.content
             };
+        },
+        convertToValidHTMLString: function (HTMLString) {
+            var tempDiv = document.createElement('div');
+            tempDiv.innerHTML = HTMLString;
+
+            return tempDiv.innerHTML;
         }
     });
 


### PR DESCRIPTION
The problem was occurring when HTMLPortlet was created with invalid HTML, during rendering it was able to broke DOM structure. To fix this error we need to make sure that HTML that will be used by HTMLPortlet is valid.

[Jira & Demo](https://jira.zenoss.com/browse/ZEN-25652?focusedCommentId=137988&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-137988)