### PR TITLE
ZEN-31099: sanitize html before inserting it

### DIFF
--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
@@ -306,7 +306,16 @@
                 value: this.content,
                 allowBlank: false,
                 height: 100,
-                width: 200
+                width: 200,
+                listeners: {
+                    afterrender: function(me) {
+                        Ext.tip.QuickTipManager.register({
+                            target: me.getId(),
+                            title : 'Warning',
+                            text  : 'Your HTML will be processed according to security rules'
+                        });
+                    }
+                }
             }];
             return fields;
         },
@@ -341,7 +350,7 @@
         },
         convertToValidHTMLString: function (HTMLString) {
             var tempDiv = document.createElement('div');
-            tempDiv.innerHTML = HTMLString;
+            tempDiv.innerHTML = Zenoss.util.sanitizeHtml(HTMLString);
 
             return tempDiv.innerHTML;
         }

--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
@@ -350,8 +350,12 @@
         },
         convertToValidHTMLString: function (HTMLString) {
             var tempDiv = document.createElement('div');
-            tempDiv.innerHTML = Zenoss.util.sanitizeHtml(HTMLString);
-
+            try {
+                tempDiv.innerHTML = Zenoss.util.sanitizeHtml(HTMLString);
+            }
+            catch {
+                tempDiv.innerHTML = HTMLString;
+            }
             return tempDiv.innerHTML;
         }
     });


### PR DESCRIPTION
According to owasp there are some vulnerabilities if we insert raw html
without sanitizing it.
Create a blacklist of tags that are forbidden to use and whitelist
of attributes that can be used and then filter the html code.

Related PR https://github.com/zenoss/zenoss-prodbin/pull/3498

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-31099?focusedCommentId=141892&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-141892)