### PR TITLE
ZEN-31253 Replace link in docs to site window portlet with new sites

### DIFF
--- a/ZenPacks/zenoss/Dashboard/__init__.py
+++ b/ZenPacks/zenoss/Dashboard/__init__.py
@@ -5,6 +5,7 @@ from zope.component import getUtility
 from Products.CMFCore.DirectoryView import registerDirectory
 from Products.ZenRelations.RelSchema import ToOne, ToManyCont
 from Products.ZenModel.UserSettings import UserSettings, UserSettingsManager
+from Products.ZenModel.ZVersion import VERSION
 from ZenPacks.zenoss.Dashboard.Dashboard import Dashboard
 log = logging.getLogger('zen.dashboard')
 
@@ -32,7 +33,7 @@ except Exception:
 
 from Products.ZenModel.ZenPack import ZenPack as ZenPackBase
 
-DEFAULT_DASHBOARD_STATE = '[{"id":"col-0","items":[{"title":"Welcome to Zenoss!","refreshInterval":3000,"config":{"siteUrl":"https://help.zenoss.com#main-content"},"xtype":"sitewindowportlet","height":399,"collapsed":false},{"title":"Google Maps","refreshInterval":300,"config":{"baselocation":"%s","pollingrate":400},"xtype":"googlemapportlet","height":400,"collapsed":false}]},{"id":"col-1","items":[{"title":"Open Events","refreshInterval":300,"config":{"stateId":"ext-gen1351"},"xtype":"eventviewportlet","height":400,"collapsed":false},{"title":"Open Events Chart","refreshInterval":300,"config":{"eventClass":"/","summaryFilter":"","daysPast":3},"xtype":"openeventsportlet","height":400,"collapsed":false}]}]'
+DEFAULT_DASHBOARD_STATE = '[{"id":"col-0","items":[{"title":"Welcome to Zenoss!","refreshInterval":3000,"config":{"siteUrl":"%s"},"xtype":"sitewindowportlet","height":399,"collapsed":false},{"title":"Google Maps","refreshInterval":300,"config":{"baselocation":"%s","pollingrate":400},"xtype":"googlemapportlet","height":400,"collapsed":false}]},{"id":"col-1","items":[{"title":"Open Events","refreshInterval":300,"config":{"stateId":"ext-gen1351"},"xtype":"eventviewportlet","height":400,"collapsed":false},{"title":"Open Events Chart","refreshInterval":300,"config":{"eventClass":"/","summaryFilter":"","daysPast":3},"xtype":"openeventsportlet","height":400,"collapsed":false}]}]'
 
 class ZenPack(ZenPackBase):
     """
@@ -45,6 +46,9 @@ class ZenPack(ZenPackBase):
 
     def _buildRelationships(self, dmd):
         log.info("Building dashboard relationships on user manager")
+        siteUrl = "https://help.zenoss.com#main-content"
+        if VERSION[0] == '6':
+            siteUrl = "https://help.zenoss.com/zsd#main-content"
         # manager
         dmd.ZenUsers.buildRelations()
         # users
@@ -66,7 +70,7 @@ class ZenPack(ZenPackBase):
             dashboard = Dashboard('default')
             dashboard.columns = 2
             dashboard.owner = 'admin'
-            dashboard.state = DEFAULT_DASHBOARD_STATE % (baselocation)
+            dashboard.state = DEFAULT_DASHBOARD_STATE % (siteUrl, baselocation)
             dmd.ZenUsers.dashboards._setObject('default', dashboard)
 
     def remove(self, dmd, leaveObjects=False):

--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
@@ -9,7 +9,11 @@
  ****************************************************************************/
 (function() {
     Ext.ns('Zenoss.Dashboard');
-    Zenoss.Dashboard.DEFAULT_SITEWINDOW_URL = Zenoss.Dashboard.DEFAULT_SITEWINDOW_URL || "https://help.zenoss.com#main-content";
+    var default_sitewindow_url = "https://help.zenoss.com#main-content";
+    if (Zenoss.env.ZENOSS_VERSION && Zenoss.env.ZENOSS_VERSION[0] == "6") {
+        default_sitewindow_url = "https://help.zenoss.com/zsd#main-content"
+    }
+    Zenoss.Dashboard.DEFAULT_SITEWINDOW_URL = Zenoss.Dashboard.DEFAULT_SITEWINDOW_URL || default_sitewindow_url;
     Zenoss.Dashboard.PortletLockedTools = [{
             xtype: 'tool',
             itemId: 'fullscreenPortlet',

--- a/ZenPacks/zenoss/Dashboard/migrate/updateDefaultSiteUrlZsd.py
+++ b/ZenPacks/zenoss/Dashboard/migrate/updateDefaultSiteUrlZsd.py
@@ -1,0 +1,45 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2019, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+
+import logging
+log = logging.getLogger("zen.migrate")
+
+import Globals
+import json
+from Products.ZenModel.migrate.Migrate import Version
+from Products.ZenModel.ZVersion import VERSION
+from Products.ZenModel.ZenPack import ZenPackMigration
+
+
+class updateDefaultSiteUrlZsd(ZenPackMigration):
+    version = Version(1, 3, 8)
+
+    def migrate(self, pack):
+        if hasattr(pack.dmd.ZenUsers, 'dashboards'):
+            changed = False
+            doc_url = "https://help.zenoss.com#main-content"
+            if VERSION[0] == '6':
+                doc_url = "https://help.zenoss.com/zsd#main-content"
+            default = pack.dmd.ZenUsers.dashboards._getOb('default', None)
+            if default:
+                default_dashboard_json = json.loads(default.state)
+                for portlet in default_dashboard_json:
+                    items = portlet['items']
+                    for item in items:
+                        if 'Welcome to Zenoss!' in item.get('title'):
+                            if doc_url not in item['config']['siteUrl']:
+                                item['config']['siteUrl'] = doc_url
+                                changed = True
+
+            if changed:
+                log.info('Committing changes')
+                default.state = json.dumps(default_dashboard_json)
+
+updateDefaultSiteUrlZsd()


### PR DESCRIPTION
We have different docs links for the 6.x and 7.x, so I made it flexible depends on Zenoss version