### PR TITLE
ZEN-31253 Set default sitewindow url later

### DIFF
--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
@@ -9,11 +9,6 @@
  ****************************************************************************/
 (function() {
     Ext.ns('Zenoss.Dashboard');
-    var default_sitewindow_url = "https://help.zenoss.com#main-content";
-    if (Zenoss.env.ZENOSS_VERSION && Zenoss.env.ZENOSS_VERSION[0] == "6") {
-        default_sitewindow_url = "https://help.zenoss.com/zsd#main-content"
-    }
-    Zenoss.Dashboard.DEFAULT_SITEWINDOW_URL = Zenoss.Dashboard.DEFAULT_SITEWINDOW_URL || default_sitewindow_url;
     Zenoss.Dashboard.PortletLockedTools = [{
             xtype: 'tool',
             itemId: 'fullscreenPortlet',
@@ -646,7 +641,11 @@
         refreshInterval: 3000,
         siteUrl: Zenoss.Dashboard.DEFAULT_SITEWINDOW_URL,
         initComponent: function(){
-
+            var default_sitewindow_url = "https://help.zenoss.com#main-content";
+            if (Zenoss.env.ZENOSS_VERSION && Zenoss.env.ZENOSS_VERSION[0] == "6") {
+                default_sitewindow_url = "https://help.zenoss.com/zsd#main-content"
+            }
+            this.siteUrl = Zenoss.Dashboard.DEFAULT_SITEWINDOW_URL || default_sitewindow_url;
             Ext.apply(this, {
                 items: [{
                     xtype: 'uxiframe',


### PR DESCRIPTION
Make assigning for `siteUrl` later, because of Zenoss.env.ZENOSS_VERSION is undefined when it called on the start of the script