### PR TITLE
Starting from Dashboard zp 1.3.4 site window portlet doesn't show graphs.

### DIFF
--- a/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
+++ b/ZenPacks/zenoss/Dashboard/browser/resources/js/defaultportlets.js
@@ -656,7 +656,10 @@
             this.callParent(arguments);
         },
         getIFrameSource: function() {
-            var siteUrl = this.siteUrl.replace('viewGraph', 'viewGraphPortlet');
+            var siteUrl = this.siteUrl;
+            if (Zenoss.env.ZENOSS_VERSION && Zenoss.env.ZENOSS_VERSION[0] == "7") {
+                siteUrl = siteUrl.replace('viewGraph', 'viewGraphPortlet');
+            }
             return siteUrl;
         },
         getConfig: function() {


### PR DESCRIPTION
In the scope of this ticket: https://jira.zenoss.com/browse/ZEN-31675 we created a new view for graphs, but it doesn't work with 6.x