### PR TITLE
ZEN-32965 Add check on backend side whether the dashboard is locked or not

### DIFF
--- a/ZenPacks/zenoss/Dashboard/facades.py
+++ b/ZenPacks/zenoss/Dashboard/facades.py
@@ -122,6 +122,8 @@ class DashboardFacade(ZuulFacade):
 
     def saveDashboardState(self, uid, state):
         dashboard = self._getObject(uid)
+        if dashboard.locked:
+            raise Exception("You cannot edit the Dashboard when it's locked")
         if dashboard.state != state:
             dashboard.state = state
 


### PR DESCRIPTION
This commit adds check whether the dashboard is locked or not when we try
to edit the dashboard. It may fix the problem with dashboard state portlet
duplication (ZEN-32965) when the dashboard is locked. Before this commit,
the dashboard was checked for locking only on browser side